### PR TITLE
Ensure interval edges are selected when timepicker is disabled

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -7,6 +7,8 @@ import {
     deepMerge,
     getDecade,
     getEl,
+    getIntervalEndDate,
+    getIntervalStartDate,
     getParsedDate,
     getWordBoundaryRegExp,
     insertAfter,
@@ -535,6 +537,13 @@ export default class Datepicker {
                         this.rangeDateTo = this.rangeDateFrom;
                         this.rangeDateFrom = date;
                     }
+
+                    // If time selection is disabled, ensure that the ranges represent the start and end
+                    // of their intervals
+                    if (!this.opts.timepicker) {
+                        this.rangeDateFrom = getIntervalStartDate(this.rangeDateFrom, this.opts.minView);
+                        this.rangeDateTo = getIntervalEndDate(this.rangeDateTo, this.opts.minView);
+                    }
                     this.selectedDates = [this.rangeDateFrom, this.rangeDateTo];
                     break;
                 case 2:
@@ -924,11 +933,17 @@ export default class Datepicker {
                 this.focusDate = new Date(this.focusDate);
             }
             if (isDateBigger(selectedDate, this.focusDate)) {
-                this.rangeDateTo =  this.selectedDates[0];
+                this.rangeDateTo = this.selectedDates[0];
                 this.rangeDateFrom = this.focusDate;
             } else {
                 this.rangeDateTo = this.focusDate;
                 this.rangeDateFrom = this.selectedDates[0];
+            }
+
+            // If time is not enabled, set the dates to the interval ranges
+            if (!this.opts.timepicker) {
+                this.rangeDateFrom = getIntervalStartDate(this.rangeDateFrom, this.opts.minView);
+                this.rangeDateTo = getIntervalEndDate(this.rangeDateTo, this.opts.minView);
             }
         }
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -371,6 +371,60 @@ export function createDate(date) {
     return resultDate;
 }
 
+/**
+ * Creates and returns a `Date` object that represents the start of the interval of a
+ * type that contains the specified date.
+ * @param {Date} date - the date for which to obtain the interval start
+ * @param {string} type - the interval type
+ * @param {Date} - the interval start
+ */
+export function getIntervalStartDate(date, type) {
+    const endDate = new Date(date);
+    switch (type) {
+        case consts.years:
+            // For year, set the month to january
+            endDate.setFullYear(endDate.getFullYear(), 0);
+        // eslint-disable-next-line no-fallthrough
+        case consts.months:
+            // For month and year, set the day to the first day of the month
+            endDate.setFullYear(endDate.getFullYear(), endDate.getMonth(), 1);
+        // eslint-disable-next-line no-fallthrough
+        case consts.days:
+        default:
+            // For day and all other views, set the time to the beginning of the day
+            endDate.setHours(0, 0, 0, 0);
+    }
+
+    return endDate;
+}
+
+/**
+ * Creates and returns a `Date` object that represents the end of the interval of a
+ * type that contains the specified date.
+ * @param {Date} date - the date for which to obtain the interval end
+ * @param {string} type - the interval type
+ * @returns {Date} - the interval end
+ */
+export function getIntervalEndDate(date, type) {
+    const endDate = new Date(date);
+    switch (type) {
+        case consts.years:
+            // For year, set the month to december
+            endDate.setFullYear(endDate.getFullYear(), 11);
+        // eslint-disable-next-line no-fallthrough
+        case consts.months:
+            // For month and year, set the day to the last day of the month
+            endDate.setFullYear(endDate.getFullYear(), endDate.getMonth() + 1, 0);
+        // eslint-disable-next-line no-fallthrough
+        case consts.days:
+        default:
+            // For day and all other views, set the time to the end of the day
+            endDate.setHours(23, 59, 59, 999);
+    }
+
+    return endDate;
+}
+
 export function getWordBoundaryRegExp(sign) {
     let symbols = '\\s|\\.|-|/|\\\\|,|\\$|\\!|\\?|:|;';
 


### PR DESCRIPTION
When time picker is disabled and range is enabled, ensure that when a range is selected the start date represents the start date/time of the min interval and the end date represents the end date/time of the min interval.